### PR TITLE
fix prefixed type on created actions

### DIFF
--- a/lib/createActions.js
+++ b/lib/createActions.js
@@ -1,5 +1,9 @@
 import createTypes from './createTypes'
-import { isNil, isEmpty, join, map, mapObjIndexed, zipObj, pipe, keys, replace, toUpper, curry, __ } from 'ramda'
+import { curry, isNil, isEmpty, join, keys, map, mapObjIndexed, merge, pipe, replace, toUpper, zipObj, __ } from 'ramda'
+
+const defaultOptions = {
+  prefix: ''
+}
 
 // matches on capital letters (except at the start & end of the string)
 const RX_CAPS = /(?!^)([A-Z])/g
@@ -23,9 +27,11 @@ const convertToTypes = (config, options) => {
 }
 
 // an action creator with additional properties
-const createActionCreator = (name, extraPropNames) => {
+const createActionCreator = (name, extraPropNames, options) => {
+  const { prefix } = merge(defaultOptions, options)
+
   // types are upcase and snakey
-  const type = camelToScreamingSnake(name)
+  const type = prefix + camelToScreamingSnake(name)
 
   // do we need extra props for this?
   const noKeys = isNil(extraPropNames) || isEmpty(extraPropNames)
@@ -41,15 +47,15 @@ const createActionCreator = (name, extraPropNames) => {
 }
 
 // build Action Creators out of an objet
-const convertToCreators = mapObjIndexed((num, key, value) => {
+const convertToCreators = (config, options) => mapObjIndexed((num, key, value) => {
   if (typeof value[key] === 'function') {
     // the user brought their own action creator
     return value[key]
   } else {
     // lets make an action creator for them!
-    return createActionCreator(key, value[key])
+    return createActionCreator(key, value[key], options)
   }
-})
+})(config)
 
 export default (config, options) => {
   if (isNil(config)) {
@@ -61,6 +67,6 @@ export default (config, options) => {
 
   return {
     Types: convertToTypes(config, options),
-    Creators: convertToCreators(config)
+    Creators: convertToCreators(config, options)
   }
 }

--- a/test/createActionsTest.js
+++ b/test/createActionsTest.js
@@ -42,6 +42,7 @@ test('custom action creators are supported', t => {
 })
 
 test('action types prefix is supported', t => {
-  const { Types } = createActions({ helloWorld: null }, { prefix: 'SUPER_' })
+  const { Types, Creators } = createActions({ helloWorld: null }, { prefix: 'SUPER_' })
   t.is(Types.HELLO_WORLD, 'SUPER_HELLO_WORLD')
+  t.is('SUPER_HELLO_WORLD', Creators.helloWorld().type)
 })


### PR DESCRIPTION
To make amends for my bug, I sorted the imports from ramda. :sweat_smile: 

I'm not entirely satisfied with my solution. I'd prefer for the action types constant to be only created (and prefixed) once, but this would have required a refactor that was probably not required.