### PR TITLE
Dependencies upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "README.md"
   ],
   "dependencies": {
-    "ramda": "^0.23.0",
-    "ramdasauce": "^1.2.0",
-    "redux": "^3.6.0"
+    "ramda": "^0.24.1",
+    "ramdasauce": "^2.0.0",
+    "redux": "^3.7.1"
   },
   "devDependencies": {
     "ava": "^0.19.0",


### PR DESCRIPTION
I am using `apisauce` and `reduxsauce` and I am using webpack to bundle them, the latest version of these two have different version of `ramda` causing big bundle size.